### PR TITLE
Fix merging of adjacent spans

### DIFF
--- a/gitma/annotation.py
+++ b/gitma/annotation.py
@@ -128,12 +128,12 @@ def search_for_startpoints(selector_list: List[Selector]) -> list:
     end_points = [selector.end for selector in selector_list]
 
     # filter redundant start points
-    start_points = [
+    start_points_filtered = [
         start_point for start_point in start_points if start_point not in end_points]
-    end_points = [
+    end_points_filtered = [
         end_point for end_point in end_points if end_point not in start_points]
 
-    return list(zip(start_points, end_points))
+    return list(zip(start_points_filtered, end_points_filtered))
 
 
 def numeric_property_values_to_int(prop_dict: dict) -> dict:


### PR DESCRIPTION
Background: We merge separate spans that cover a continuous logical span of text. E.g: [(0, 17), (17, 35)] -> [(0, 35)]

Previously we sometimes encountered negative span annotations like this one: (208, 147). This was caused by incorrect merging of adjacent annotations. Instead of filtering the end positions using the original start positions we filtered using the already filtered start positions. As a result no end positions were ever removed, meaning the function produced two lists of different lengths, the longer of which (with the end positions) was truncated by the call to zip.