### PR TITLE
Fix to compensate for wrong date format annotation.py

### DIFF
--- a/gitma/annotation.py
+++ b/gitma/annotation.py
@@ -38,7 +38,7 @@ def get_date(annotation_dict: dict) -> datetime:
     try:
         timestamp = datetime.strptime(annotation_iso_datetime, '%Y-%m-%dT%H:%M:%S.%f%z')
     except ValueError:
-        timestamp = datetime.strptime(annotation_iso_datetime, '%Y-%m-%dT%H:%M:%S')
+        timestamp = datetime.strptime(annotation_iso_datetime + '+02:00', '%Y-%m-%dT%H:%M:%S%z')
     return timestamp
 
 

--- a/gitma/annotation.py
+++ b/gitma/annotation.py
@@ -35,7 +35,11 @@ def get_system_properties(annotation_dict: dict) -> str:
 def get_date(annotation_dict: dict) -> datetime:
     annotation_iso_datetime = get_system_properties(annotation_dict)[Tag.SYSTEM_PROPERTY_UUID_CATMA_MARKUPTIMESTAMP][0]
     # not using datetime.fromisoformat here because it doesn't handle a timezone component without a colon separator
-    return datetime.strptime(annotation_iso_datetime, '%Y-%m-%dT%H:%M:%S.%f%z')
+    try:
+        timestamp = datetime.strptime(annotation_iso_datetime, '%Y-%m-%dT%H:%M:%S.%f%z')
+    except ValueError:
+        timestamp = datetime.strptime(annotation_iso_datetime, '%Y-%m-%dT%H:%M:%S')
+    return timestamp
 
 
 def get_author(annotation_dict: dict):

--- a/gitma/annotation.py
+++ b/gitma/annotation.py
@@ -38,6 +38,10 @@ def get_date(annotation_dict: dict) -> datetime:
     try:
         timestamp = datetime.strptime(annotation_iso_datetime, '%Y-%m-%dT%H:%M:%S.%f%z')
     except ValueError:
+        # older GitMA versions wrote the timestamp without a timezone component, which will cause the above to fail
+        # as a limited amount of annotations were created using these versions we assume CEST and append its offset to allow parsing to succeed
+        # if you used older GitMA versions to create annotations and an accurate timestamp is important to you, consider correcting the source data
+        # or modify the offset below
         timestamp = datetime.strptime(annotation_iso_datetime + '+02:00', '%Y-%m-%dT%H:%M:%S%z')
     return timestamp
 


### PR DESCRIPTION
_write_annotation.py used to write the date format incorrectly. This fix allows to load such annotation collections