### PR TITLE
Ensure setup.py compatiblity with recent Python versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,9 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     description="Load CATMA annotations from their Git data",
     url="https://github.com/forTEXT/gitma",
-    python_requires="==3.9.*",
+    python_requires=">3.9",
     install_requires=[
-        "cvxopt==1.2.7",
+        "cvxopt",
         "jupyter",
         "networkx",
         "nltk",


### PR DESCRIPTION
I do not know why the `cvxopt` version was pinned, but due to changes in `configparser` (a standard library module), the required version can no longer be installed with recent Python versions.

In my limited testing, I did not encounter any issues with this patch.