### PR TITLE
Inter Annotator Agreement Fixes

### DIFF
--- a/gitma/_metrics.py
+++ b/gitma/_metrics.py
@@ -196,7 +196,8 @@ def get_annotation_pairs(
         ac2: AnnotationCollection,
         tag_filter: list = None,
         filter_both_ac: bool = False,
-        property_filter: str = None) -> List[Tuple[Annotation]]:
+        property_filter: str = None,
+        verbose: bool = True) -> List[Tuple[Annotation]]:
     """Returns list of all overlapping annotations in two annotation collections.
     tag_filter can be defined as list of tag names if not all annotations are included.
 
@@ -266,20 +267,21 @@ def get_annotation_pairs(
             an_pair) for an_pair in pair_list if an_pair[1].tag.name != '#None#']
     ) * 100
 
-    print(
-        textwrap.dedent(
-            f"""
-            ==============================================
-            ==============================================
-            Finished search for overlapping annotations in:
-            - {ac1.name}
-            - {ac2.name}
-            Could match {len(pair_list)} annotations.
-            Average overlap is {round(string_difference, 2)} %.
-            Couldn't match {missing_an2_annotations} annotation(s) in first annotation collection.
-            """
+    if verbose:
+        print(
+            textwrap.dedent(
+                f"""
+                ==============================================
+                ==============================================
+                Finished search for overlapping annotations in:
+                - {ac1.name}
+                - {ac2.name}
+                Could match {len(pair_list)} annotations.
+                Average overlap is {round(string_difference, 2)} %.
+                Couldn't match {missing_an2_annotations} annotation(s) in first annotation collection.
+                """
+            )
         )
-    )
 
     return pair_list
 

--- a/gitma/project.py
+++ b/gitma/project.py
@@ -708,8 +708,8 @@ class CatmaProject:
 
     def get_iaa(
         self,
-        ac1_name: str,
-        ac2_name: str,
+        ac1_name: str | AnnotationCollection,
+        ac2_name: str | AnnotationCollection,
         tag_filter: list = None,
         filter_both_ac: bool = False,
         level: str = 'tag',
@@ -741,9 +741,14 @@ class CatmaProject:
             distance_function = interval_distance
         else:
             distance_function = binary_distance
-
-        ac1 = self.ac_dict[ac1_name]
-        ac2 = self.ac_dict[ac2_name]
+        if isinstance(ac1_name, str):
+            ac1 = self.ac_dict[ac1_name]
+        else:
+            ac1 = ac1_name
+        if isinstance(ac2_name, str):
+            ac2 = self.ac_dict[ac2_name]
+        else:
+            ac2 = ac2_name
 
         # create pairs of best matching annotations
         annotation_pairs = get_annotation_pairs(

--- a/gitma/project.py
+++ b/gitma/project.py
@@ -715,6 +715,7 @@ class CatmaProject:
         level: str = 'tag',
         include_empty_annotations: bool = True,
         distance: str = 'binary',
+        verbose: bool = False,
         return_as_dict: bool = False) -> None:
         """Computes Inter Annotator Agreement for 2 Annotation Collections.
         See the [demo notebook](https://github.com/forTEXT/gitma/blob/main/demo/notebooks/inter_annotator_agreement.ipynb)
@@ -751,7 +752,8 @@ class CatmaProject:
             tag_filter=tag_filter,
             filter_both_ac=filter_both_ac,
             property_filter=level.replace(
-                'prop:', '') if 'prop:' in level else None
+                'prop:', '') if 'prop:' in level else None,
+            verbose=verbose,
         )
 
         # transform annotation pairs to data format the nltk AnnotationTask class takes as input
@@ -767,16 +769,17 @@ class CatmaProject:
             print(f"Couldn't find compute IAA for {level} due to missing overlapping annotations with the given settings.")
             pi, kappa, alpha = (0, 0, 0)
 
-        print(textwrap.dedent(
-            f"""
-            Results for "{level}"
-            -------------{len(level) * '-'}-
-            Scott's Pi:          {pi}
-            Cohen's Kappa:       {kappa}
-            Krippendorf's Alpha: {alpha}
-            ===============================================
-            """
-        ))
+        if verbose:
+            print(textwrap.dedent(
+                f"""
+                Results for "{level}"
+                -------------{len(level) * '-'}-
+                Scott's Pi:          {pi}
+                Cohen's Kappa:       {kappa}
+                Krippendorf's Alpha: {alpha}
+                ===============================================
+                """
+            ))
 
         if return_as_dict:
             return {
@@ -785,11 +788,12 @@ class CatmaProject:
                 "Krippendorf's Alpha": alpha
             }
         else:
-            print(textwrap.dedent(
-                f"""Confusion Matrix
-                -------
-                """
-            ))
+            if verbose:
+                print(textwrap.dedent(
+                    f"""Confusion Matrix
+                    -------
+                    """
+                ))
             return get_confusion_matrix(pair_list=annotation_pairs, level=level)
 
     def gamma_agreement(


### PR DESCRIPTION
This contains two commits:

* One to add a verbosity option to get_iaa, default behavior is verbose and thus remains unchanged,
* and one to allow for passing AnnotationCollections directly to get_iaa (strings also still work). 

The latter is a broader issue that is not really addressed in this PR. A lot of places rely on name-based identification of annotation collections (e.g. the `ac_dict` member of CatmaProject). It is very natural (in the webui) to create an *annotation collection* with the same name for the same schema being applied to each text in a project. The workaround is to prefix all annotation collection names with a text identifier (e.g. in the web ui).