### PR TITLE
Chore: Update readthedocs to use ubuntu-24.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.9"
 


### PR DESCRIPTION
As of June 1, 2026, Ubuntu 20.04 will be deprecated as a build image of Read The Docs (see [announcement](https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/)).

This PR updates the build image to Ubuntu 24.04.