### PR TITLE
Implement interannotator agreement calculation for Krippendorffs Alpha 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,19 @@
+# development tooling
 .git
 .idea
+
+# python
+.venv
 .ipynb_checkpoints
-user_projects
 __pycache__
+requ.txt
+build
+
+# user-based data and sample project data
+user_projects
 *.egg-info
 *.csv
 own_work.py
 own_notebook.ipynb
 _gamma_own.py
-requ.txt
 dev_dashboard.ipynb

--- a/demo/notebooks/inter_annotator_agreement.ipynb
+++ b/demo/notebooks/inter_annotator_agreement.ipynb
@@ -185,8 +185,35 @@
     "Additionally, both methods return a confusion matrix to give an insight into the relation between the tags.\n",
     "As you can see in the matrices, in 2 cases an annotation with the tag 'non_event' in annotation collection 1\n",
     "has a best match in annotation collection 2 with the same tag.\n",
-    "Compare this with the line plot above.\n",
+    "Compare this with the line plot above."
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "To compute the Krippendorff's alpha agreement for two or more annotatation collections, you can use the `calculate_krippendorffs_alpha()` method.\n",
+    "Krippendorff's alpha can be calculated for two or more annotation collections. If you do not supply a list of annotation collections,\n",
+    "the method will use all annotation collections in the project.\n",
     "\n",
+    "The method returns the value for Krippendorff's alpha and a co-occurrence matrix of tag matches."
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "krippendorffs_alpha, cooccurence_matrix = my_project.calculate_krippendorffs_alpha(\n",
+    "    ac_names=['ac_1', 'ac_2', 'gold_annotation']\n",
+    ")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
     "### Filter by tags <a class=\"anchor\" id=\"3.2\"></a>\n",
     "\n",
     "There may occur cases in which you don't want to include all annotations in the computing of\n",
@@ -208,13 +235,13 @@
    "execution_count": null
   },
   {
-   "cell_type": "markdown",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "As the confusion matrix shows for the calculation of Scott's Pi, only the annotations from annotation collection 1\n",
     "with the tag 'process_event' have been taken into account.\n",
     "From annotation collection 2 there are still two annotations considered, with the tags 'stative_event' and 'change_of_state' respectively.\n",
-    "But we can filter both annotation collections, too: "
+    "But we can filter both annotation collections, too:"
    ]
   },
   {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ def setup(app):
 # -- Project information -----------------------------------------------------
 
 project = 'GitMA'
-copyright = '2022, Michael Vauth'
+copyright = '2026, Michael Vauth'
 author = 'Michael Vauth'
 
 # The full version, including alpha/beta/rc tags

--- a/gitma/_metrics.py
+++ b/gitma/_metrics.py
@@ -330,6 +330,7 @@ def get_iaa_data(
         for an_index, an in enumerate(pair):
             if level == 'tag':
                 yield an_index, index, an.tag.name
+            # TODO: naming a prop "prop:" would break this, right?
             elif an.properties and level.replace('prop:', '') in an.properties:
                 yield an_index, index, an.properties[level.replace('prop:', '')][0]
             else:

--- a/gitma/project.py
+++ b/gitma/project.py
@@ -1052,8 +1052,8 @@ class CatmaProject:
 
             # Get annotation pairs for the current AC combination
             annotation_pairs = get_annotation_pairs(
-                project.ac_dict[ac_first_name],
-                project.ac_dict[ac_second_name],
+                self.ac_dict[ac_first_name],
+                self.ac_dict[ac_second_name],
                 filter_both_ac=filter_both_ac,
                 tag_filter=tag_filter,
             )

--- a/gitma/project.py
+++ b/gitma/project.py
@@ -120,6 +120,7 @@ def load_annotation_collections(
         included_acs: list = None,
         excluded_acs: list = None,
         ac_filter_keyword: str = None) -> Tuple[List[AnnotationCollection], Dict[str, AnnotationCollection]]:
+    # !TODO: add remark that just one filter option is possible at a time, filters are exclusive
     """Generates list and dict of CATMA annotation collections.
 
     Args:

--- a/gitma/project.py
+++ b/gitma/project.py
@@ -173,7 +173,7 @@ def load_annotation_collections(
     return annotation_collections, ac_dict
 
 
-def test_tageset_directory(
+def test_tagset_directory(
         project_uuid: str,
         tagset_uuid: str) -> bool:
     """Tests if tagset has header.json to filter empty tagsets from loading process.
@@ -185,10 +185,10 @@ def test_tageset_directory(
     Returns:
         boolean: True if header.json exists.
     """
-    tageset_dir = f'{project_uuid}/tagsets/{tagset_uuid}/header.json'
-    if os.path.isfile(tageset_dir):
+    tagset_dir = f'{project_uuid}/tagsets/{tagset_uuid}/header.json'
+    if os.path.isfile(tagset_dir):
         return True
-
+    return False
 
 def load_tagsets(project_uuid: str) -> Tuple[List[Tagset], Dict[str, Tagset]]:
     """Generates list and dict of tagsets.
@@ -206,7 +206,7 @@ def load_tagsets(project_uuid: str) -> Tuple[List[Tagset], Dict[str, Tagset]]:
             tagset_uuid=directory
         ) for directory in os.listdir(tagsets_directory)
         # ignore empty tagsets
-        if test_tageset_directory(project_uuid, directory)
+        if test_tagset_directory(project_uuid, directory)
     ]
     tagset_dict = {tagset.uuid: tagset for tagset in tagsets}
 
@@ -267,7 +267,7 @@ class CatmaProject:
             load_from_gitlab: bool = False,
             gitlab_access_token: str = None,
             backup_directory: str = './'):
-        # get the current directory, to return to after loading the project
+        # get the current directory to return to after loading the project
         cwd = os.getcwd()
 
         # TODO: what we're calling UUID here is actually the full GitLab project name, which is unlikely to change and contains a UUID

--- a/gitma/project.py
+++ b/gitma/project.py
@@ -1009,8 +1009,7 @@ class CatmaProject:
 
         return matrix
 
-    # !TODO rename this function
-    def get_annotation_multiple_annotators(
+    def get_iaa_data_for_multiple_annotators(
             self,
             ac_names: list = [],
             tag_filter: list = [],  # to be passed to gitma get_annotation_pairs function
@@ -1019,7 +1018,7 @@ class CatmaProject:
             property_filter: str = None,
     ) -> set:
         """
-        Get annotation data from Catma project via API or local directory.
+        Get annotation data in the NLTK format for IAA calculation for two or more annotators without duplicate pairs.
         Args:
             ac_names (list): List of annotation collection names to include in the IAA calculation. If empty, all ACs in the project will be used.
             tag_filter (list): List of tags that should be included for iaa calculation. If empty, all tags will be used. Passed to get_annotation_pairs function of gitma.
@@ -1091,7 +1090,7 @@ class CatmaProject:
 
         return pairwise_iaa_data
 
-    # TODO: use level parameter instead of tag_filter, implement filtering for properties?
+    # TODO: implement level parameter
     def calculate_krippendorffs_alpha(
             self,
             ac_names: list = [],

--- a/gitma/project.py
+++ b/gitma/project.py
@@ -861,9 +861,15 @@ class CatmaProject:
 
         return AnnotationTask(data=data, distance=distance_function), annotation_pairs
 
-    def _return_iaa_result(self, metric_function, metric_name, level, confusion_matrix, verbose) -> Tuple[Union[float, Any], pd.DataFrame]:
+    def _return_iaa_result(self, metric_function, metric_name, level, confusion_matrix, verbose, annotation_task_override: AnnotationTask = None) -> Tuple[Union[float, Any], pd.DataFrame]:
         try:
-            metric_result = metric_function()
+            # TODO: think of a better way to handle this special case for Krippendorffs alpha,
+            # as IAA calculation for multiple annotators needs special merging of annotations (see get_iaa_data_for_multiple_annotators
+            # might want to add an additional iaa_data field to self
+            if annotation_task_override and metric_function.__name__ == 'alpha':
+                metric_result = annotation_task_override.alpha()
+            else:
+                metric_result = metric_function()
         except ZeroDivisionError:
             print(f"Couldn't calculate {metric_name} for level '{level}' due to missing matching annotations with the given settings.")
             return
@@ -1121,19 +1127,7 @@ class CatmaProject:
         annotation_task = AnnotationTask(data=annotation_pairs, distance=distance_function)
         co_matrix = self.get_cooccurence_matrix(annotation_pairs)
 
-        if verbose:
-            print(textwrap.dedent(
-                f"""
-                Results for Krippendorff's alpha for project "{self.name}"
-                -------------{len(self.name) * '-'}-----------
-                Krippendorf's Alpha: {annotation_task.alpha()}
-                """
-            ))
-            # !TODO: should we print a warning that this is not a confusion matrix, but a co-occurence matrix?
-            print(co_matrix)
-
-        # !TODO: look at the format of the return values, might want to follow the same format as other IAA calculations
-        return annotation_task.alpha(), co_matrix
+        return self._return_iaa_result(annotation_task.alpha, "Krippendorff's Alpha", 'tag', co_matrix, verbose, annotation_task_override=annotation_task)
 
     def gamma_agreement(
         self,

--- a/gitma/project.py
+++ b/gitma/project.py
@@ -970,7 +970,7 @@ class CatmaProject:
 
         return self._return_iaa_result(annotation_task.kappa, "Cohen's Kappa", level, confusion_matrix, verbose)
 
-    def get_cooccurence_matrix(self, annotationdata):
+    def get_cooccurence_matrix(self, annotationdata) -> pd.DataFrame:
         """Generates cooccurence matrix for annotation data
 
         Args:
@@ -1009,7 +1009,7 @@ class CatmaProject:
             tag_filter: list = [],  # to be passed to gitma get_annotation_pairs function
             filter_both_ac: bool = True,  # to be passed to gitma get_annotation_pairs function
             include_empty_annotations: bool = True,  # passed to get_iaa_data function of gitma
-    ):
+    ) -> set:
         """
         Get annotation data from Catma project via API or local directory.
         Args:
@@ -1019,7 +1019,7 @@ class CatmaProject:
             include_empty_annotations (bool): Whether to include empty annotations in the IAA data. If `False`, only annotations with a matching annotation in the second collection are\
                                                 included. Default is True. Passed to get_iaa_data function of gitma.
         Returns:
-            List of annotation tuples in NLTK format for IAA calculation.
+            Set of annotation tuples in [NLTK format](https://www.nltk.org/api/nltk.metrics.agreement.html#nltk.metrics.agreement.AnnotationTask.__init__) for IAA calculation.
         """
 
         if ac_names == []:
@@ -1085,7 +1085,7 @@ class CatmaProject:
             filter_both_ac: bool = True,  # to be passed to gitma get_annotation_pairs function
             include_empty_annotations: bool = True,  # passed to get_iaa_data function of gitma
             distance: str = 'binary',
-    ):
+    ) -> Tuple[Union[float, Any], pd.DataFrame]:
         """
         Computes Krippendorff's Alpha inter-annotator-agreement (IAA) metric for multiple annotation collections based on NLTK implementation.
         See the [demo notebook](https://github.com/forTEXT/gitma/blob/main/demo/notebooks/inter_annotator_agreement.ipynb) for details.
@@ -1100,7 +1100,7 @@ class CatmaProject:
                                           [NLTK API](https://www.nltk.org/api/nltk.metrics.html) for further information. Defaults to 'binary'.
 
         Returns:
-            A Pandas DataFrame with a co-occurence matrix
+            Tuple[Union[Float, Any], pd.DataFrame]: The Krippendorff's alpha score and a Pandas DataFrame with a co-ocurrence matrix.
         """
 
         if distance == 'interval':

--- a/gitma/project.py
+++ b/gitma/project.py
@@ -2,11 +2,17 @@ import subprocess
 import os
 import json
 import textwrap
+from collections import defaultdict, Counter
+from itertools import combinations
+from typing import Any, Dict, List, Tuple, Union, Generator
+
 import gitlab
 import pygit2
 import pandas as pd
 import plotly.graph_objects as go
-from typing import Any, Dict, List, Tuple, Union, Generator
+from nltk.metrics.agreement import AnnotationTask
+from nltk.metrics import interval_distance, binary_distance
+
 from gitma.text import Text
 from gitma.tagset import Tagset
 from gitma.annotation_collection import AnnotationCollection
@@ -16,9 +22,6 @@ from gitma._write_annotation import write_annotation_json
 from gitma._gold_annotation import create_gold_annotations
 from gitma._vizualize import plot_interactive, plot_annotation_progression
 from gitma._metrics import get_annotation_pairs, get_iaa_data, get_confusion_matrix, gamma_agreement, EmptyAnnotation
-from nltk.metrics.agreement import AnnotationTask
-from nltk.metrics import interval_distance, binary_distance
-
 
 def load_gitlab_project(
         gitlab_access_token: str,
@@ -966,6 +969,155 @@ class CatmaProject:
         confusion_matrix = get_confusion_matrix(annotation_pairs, level)
 
         return self._return_iaa_result(annotation_task.kappa, "Cohen's Kappa", level, confusion_matrix, verbose)
+
+    def get_cooccurence_matrix(self, annotationdata):
+        """Generates cooccurence matrix for annotation data
+
+        Args:
+            annotationdata (List[List[coderid,itemid,tag]]): List of overlapping annotations as lists.
+
+        Returns:
+            pd.DataFrame: Cooccurence matrix as pandas data frame.
+        """
+
+        # group tags by item
+        items_tags_grouped = defaultdict(list)
+        for coderid, itemid, tag in annotationdata:
+            items_tags_grouped[itemid].append(tag)
+
+        # count co-coccurences of tags
+        cooccurence_counter = Counter()
+        for tags in items_tags_grouped.values():
+            for pair in combinations(sorted(tags), 2):  # all possible combinations of two elements
+                cooccurence_counter[pair] += 1
+
+        # matrix
+        all_tags = sorted(set(tag for _, _, tag in annotationdata))
+
+        matrix = pd.DataFrame(0, index=all_tags, columns=all_tags)
+
+        for (a, b), count in cooccurence_counter.items():
+            matrix.loc[a, b] = count
+            matrix.loc[b, a] = count
+
+        return matrix
+
+    # !TODO rename this function
+    def get_annotation_multiple_annotators(
+            self,
+            ac_names: list = [],
+            tag_filter: list = [],  # to be passed to gitma get_annotation_pairs function
+            filter_both_ac: bool = True,  # to be passed to gitma get_annotation_pairs function
+            include_empty_annotations: bool = True,  # passed to get_iaa_data function of gitma
+    ):
+        """
+        Get annotation data from Catma project via API or local directory.
+        Args:
+            ac_names (list): List of annotation collection names to include in the IAA calculation. If empty, all ACs in the project will be used.
+            tag_filter (list): List of tags that should be included for iaa calculation. If empty, all tags will be used. Passed to get_annotation_pairs function of gitma.
+            filter_both_ac (bool): Whether to apply tag_filter on both ACs in the pair or just on the first AC. Default is True. Passed to get_annotation_pairs function of gitma.
+            include_empty_annotations (bool): Whether to include empty annotations in the IAA data. If `False`, only annotations with a matching annotation in the second collection are\
+                                                included. Default is True. Passed to get_iaa_data function of gitma.
+        Returns:
+            List of annotation tuples in NLTK format for IAA calculation.
+        """
+
+        if ac_names == []:
+            print("No annotation collection names provided, using all ACs in the project.")
+            ac_names = list(project.ac_dict.keys())
+        else:
+            print("Using provided annotation collection names: ", ac_names)
+
+        if tag_filter == []:
+            print("No tag filter provided, using all annotations.")
+        else:
+            print(f"Using provided tag filter: {tag_filter}, with filter_both_ac set to {filter_both_ac}.")
+
+        # Get annotation collection combinations and enumerate them for IAA calculation
+        # enumerate for mapping back to original indices after getting annotation pairs
+        ac_names_enum = list(enumerate(ac_names))
+
+        # All pairwise combinations of ACs
+        ac_combinations = list(combinations(range(len(ac_names)), 2))
+
+        # Set to store all matching annotations. As we do pairwise comparison, we do not want to keep duplicates from the pairwise comparison
+        pairwise_iaa_data = set()
+
+        for ac_pair in ac_combinations:
+            ac_first_index = ac_pair[
+                0]  # this is the enumerated index of the first AC in the pair, in current setup, it is always 0th index since we are comparing the first AC against the rest of ACs.
+            ac_second_index = ac_pair[
+                1]  # this is the enumerated index of the second AC in pairwise comparison, could be 1,2,3,...nth
+            ac_first_name = ac_names_enum[ac_first_index][1]  # name of the first AC in the pair
+            ac_second_name = ac_names_enum[ac_second_index][1]  # name of the second AC in the pair
+
+            # Get annotation pairs for the current AC combination
+            annotation_pairs = get_annotation_pairs(
+                project.ac_dict[ac_first_name],
+                project.ac_dict[ac_second_name],
+                filter_both_ac=filter_both_ac,
+                tag_filter=tag_filter,
+            )
+
+            # Converts gitma annotation pairs to IAA data format (Coder, Item, Label)
+            iaa_data = list(
+                get_iaa_data(annotation_pairs,
+                             include_empty_annotations=include_empty_annotations)
+            )
+
+            # Map the coder indices in IAA data back to the original AC indices. Only first value in the tuple is changed, which is the coder index
+            coder_map = {
+                0: ac_first_index,
+                1: ac_second_index
+            }
+
+            coderid_mapped_iaa_data = [(coder_map[coder], item, label) for coder, item, label in iaa_data]
+
+            # add the IAA data for the current AC combination to final set
+            pairwise_iaa_data.update(coderid_mapped_iaa_data)
+
+        return pairwise_iaa_data
+
+    def calculate_krippendorff(
+            self,
+            ac_names: list = [],
+            tag_filter: list = [],  # to be passed to gitma get_annotation_pairs function
+            filter_both_ac: bool = True,  # to be passed to gitma get_annotation_pairs function
+            include_empty_annotations: bool = True,  # passed to get_iaa_data function of gitma
+            distance: str = 'binary',
+    ):
+        """
+        Computes Krippendorff's Alpha inter-annotator-agreement (IAA) metric for multiple annotation collections based on NLTK implementation.
+        See the [demo notebook](https://github.com/forTEXT/gitma/blob/main/demo/notebooks/inter_annotator_agreement.ipynb) for details.
+
+        Args:
+            ac_names (list): List of annotation collection names for IAA calculation. If empty, all ACs in the project will be used.
+            tag_filter (list): List of tags that should be included for iaa calculation. If empty, all tags will be used. Passed to get_annotation_pairs function of gitma.
+            filter_both_ac (bool): Whether to apply tag_filter on both ACs in the pair or just on the first AC. Default is True. Passed to get_annotation_pairs function of gitma.
+            include_empty_annotations (bool): Whether to include empty annotations in the IAA data. If `False`, only annotations with a matching annotation in the second collection are\
+                                                included. Default is True. Passed to get_iaa_data function of gitma.
+            distance (str, optional): The IAA distance function. Either 'binary' or 'interval'. See the\
+                                          [NLTK API](https://www.nltk.org/api/nltk.metrics.html) for further information. Defaults to 'binary'.
+
+        Returns:
+            A Pandas DataFrame with a co-occurence matrix
+        """
+
+        if distance == 'interval':
+            distance_function = interval_distance
+        else:
+            distance_function = binary_distance
+
+        # get matching annotation pairs
+        annotation_pairs = self.get_annotation_multiple_annotators(project, ac_names, tag_filter, filter_both_ac,
+                                                              include_empty_annotations)
+
+        annotation_task = AnnotationTask(data=annotation_pairs, distance=distance_function)
+        print("Krippendorff's alpha [NLTK]: ", annotation_task.alpha())
+
+        co_matrix = self.get_cooccurence_matrix(annotation_pairs)
+        # !TODO: look at the format of the return values, might want to follow the same format as other IAA calculations
+        return annotation_task.alpha(), co_matrix
 
     def gamma_agreement(
         self,

--- a/gitma/project.py
+++ b/gitma/project.py
@@ -733,7 +733,7 @@ class CatmaProject:
         verbose: bool = True,
         return_as_dict: bool = False) -> None:
         """
-        This method is deprecated! See `calculate_scotts_pi` and `calculate_cohens_kappa`.
+        This method is deprecated! See `calculate_scotts_pi`, `calculate_cohens_kappa` and `calculate_krippendorffs_alpha`.
 
         Computes Inter-Annotator-Agreement for two annotation collections.
         See the [demo notebook](https://github.com/forTEXT/gitma/blob/main/demo/notebooks/inter_annotator_agreement.ipynb) for details.
@@ -971,11 +971,11 @@ class CatmaProject:
 
         return self._return_iaa_result(annotation_task.kappa, "Cohen's Kappa", level, confusion_matrix, verbose)
 
-    def get_cooccurence_matrix(self, annotationdata) -> pd.DataFrame:
+    def get_cooccurence_matrix(self, annotationdata: set) -> pd.DataFrame:
         """Generates cooccurence matrix for annotation data
 
         Args:
-            annotationdata (List[List[coderid,itemid,tag]]): List of overlapping annotations as lists.
+            annotationdata (Set[List[coderid,itemid,tag]]): List of overlapping annotations as a set.
 
         Returns:
             pd.DataFrame: Cooccurence matrix as pandas data frame.
@@ -1045,10 +1045,8 @@ class CatmaProject:
         pairwise_iaa_data = set()
 
         for ac_pair in ac_combinations:
-            ac_first_index = ac_pair[
-                0]  # this is the enumerated index of the first AC in the pair, in current setup, it is always 0th index since we are comparing the first AC against the rest of ACs.
-            ac_second_index = ac_pair[
-                1]  # this is the enumerated index of the second AC in pairwise comparison, could be 1,2,3,...nth
+            ac_first_index = ac_pair[0]  # this is the enumerated index of the first AC in the pair, in current setup, it is always 0th index since we are comparing the first AC against the rest of ACs.
+            ac_second_index = ac_pair[1]  # this is the enumerated index of the second AC in pairwise comparison, could be 1,2,3,...nth
             ac_first_name = ac_names_enum[ac_first_index][1]  # name of the first AC in the pair
             ac_second_name = ac_names_enum[ac_second_index][1]  # name of the second AC in the pair
 
@@ -1101,7 +1099,7 @@ class CatmaProject:
                                           [NLTK API](https://www.nltk.org/api/nltk.metrics.html) for further information. Defaults to 'binary'.
 
         Returns:
-            Tuple[Union[Float, Any], pd.DataFrame]: The Krippendorff's alpha score and a Pandas DataFrame with a co-ocurrence matrix.
+            Tuple[Union[Float, Any], pd.DataFrame]: The score for Krippendorff's alpha and a Pandas DataFrame with a co-ocurrence matrix.
         """
 
         if distance == 'interval':
@@ -1110,8 +1108,12 @@ class CatmaProject:
             distance_function = binary_distance
 
         # get matching annotation pairs
-        annotation_pairs = self.get_annotation_multiple_annotators(project, ac_names, tag_filter, filter_both_ac,
-                                                              include_empty_annotations)
+        annotation_pairs = self.get_annotation_multiple_annotators(
+            ac_names,
+            tag_filter,
+            filter_both_ac,
+            include_empty_annotations
+        )
 
         annotation_task = AnnotationTask(data=annotation_pairs, distance=distance_function)
         print("Krippendorff's alpha [NLTK]: ", annotation_task.alpha())

--- a/gitma/project.py
+++ b/gitma/project.py
@@ -1016,6 +1016,7 @@ class CatmaProject:
             tag_filter: list = [],  # to be passed to gitma get_annotation_pairs function
             filter_both_ac: bool = True,  # to be passed to gitma get_annotation_pairs function
             include_empty_annotations: bool = True,  # passed to get_iaa_data function of gitma
+            property_filter: str = None,
     ) -> set:
         """
         Get annotation data from Catma project via API or local directory.
@@ -1025,6 +1026,7 @@ class CatmaProject:
             filter_both_ac (bool): Whether to apply tag_filter on both ACs in the pair or just on the first AC. Default is True. Passed to get_annotation_pairs function of gitma.
             include_empty_annotations (bool): Whether to include empty annotations in the IAA data. If `False`, only annotations with a matching annotation in the second collection are\
                                                 included. Default is True. Passed to get_iaa_data function of gitma.
+            property_filter (str, optional): Property to filter by as a string with the property name. If None, all properties will be used. Passed to get_annotation_pairs function of gitma.
         Returns:
             Set of annotation tuples in [NLTK format](https://www.nltk.org/api/nltk.metrics.agreement.html#nltk.metrics.agreement.AnnotationTask.__init__) for IAA calculation.
         """
@@ -1039,6 +1041,11 @@ class CatmaProject:
             print("No tag filter provided, using all annotations.")
         else:
             print(f"Using provided tag filter: {tag_filter}, with filter_both_ac set to {filter_both_ac}.")
+
+        if not property_filter:
+            print("No property filter provided, using all annotations.")
+        else:
+            print(f"Using provided property filter: {property_filter}.")
 
         # Get annotation collection combinations and enumerate them for IAA calculation
         # enumerate for mapping back to original indices after getting annotation pairs
@@ -1062,6 +1069,7 @@ class CatmaProject:
                 self.ac_dict[ac_second_name],
                 filter_both_ac=filter_both_ac,
                 tag_filter=tag_filter,
+                property_filter=property_filter,
             )
 
             # Converts gitma annotation pairs to IAA data format (Coder, Item, Label)
@@ -1087,9 +1095,10 @@ class CatmaProject:
     def calculate_krippendorffs_alpha(
             self,
             ac_names: list = [],
-            tag_filter: list = [],  # to be passed to gitma get_annotation_pairs function
-            filter_both_ac: bool = True,  # to be passed to gitma get_annotation_pairs function
-            include_empty_annotations: bool = True,  # passed to get_iaa_data function of gitma
+            tag_filter: list = [],
+            filter_both_ac: bool = True,
+            include_empty_annotations: bool = True,
+            property_filter: str = None,
             distance: str = 'binary',
             verbose: bool = True
     ) -> Tuple[Union[float, Any], pd.DataFrame]:
@@ -1103,6 +1112,7 @@ class CatmaProject:
             filter_both_ac (bool): Whether to apply tag_filter on both ACs in the pair or just on the first AC. Default is True. Passed to get_annotation_pairs function of gitma.
             include_empty_annotations (bool): Whether to include empty annotations in the IAA data. If `False`, only annotations with a matching annotation in the second collection are\
                                                 included. Default is True. Passed to get_iaa_data function of gitma.
+            property_filter (str, optional): Property to filter by. If None, all properties will be used. Passed to get_annotation_pairs function of gitma.
             distance (str, optional): The IAA distance function. Either 'binary' or 'interval'. See the\
                                           [NLTK API](https://www.nltk.org/api/nltk.metrics.html) for further information. Defaults to 'binary'.
             verbose (bool, optional): Whether to print results to stdout. Defaults to `True`.
@@ -1117,11 +1127,12 @@ class CatmaProject:
             distance_function = binary_distance
 
         # get matching annotation pairs
-        annotation_pairs = self.get_annotation_multiple_annotators(
-            ac_names,
-            tag_filter,
-            filter_both_ac,
-            include_empty_annotations
+        annotation_pairs = self.get_iaa_data_for_multiple_annotators(
+            ac_names=ac_names,
+            tag_filter=tag_filter,
+            filter_both_ac=filter_both_ac,
+            include_empty_annotations=include_empty_annotations,
+            property_filter=property_filter
         )
 
         annotation_task = AnnotationTask(data=annotation_pairs, distance=distance_function)

--- a/gitma/project.py
+++ b/gitma/project.py
@@ -868,8 +868,10 @@ class CatmaProject:
             # might want to add an additional iaa_data field to self
             if annotation_task_override and metric_function.__name__ == 'alpha':
                 metric_result = annotation_task_override.alpha()
+                matrix_type = "Co-occurrence matrix"
             else:
                 metric_result = metric_function()
+                matrix_type = "Confusion matrix"
         except ZeroDivisionError:
             print(f"Couldn't calculate {metric_name} for level '{level}' due to missing matching annotations with the given settings.")
             return
@@ -885,8 +887,8 @@ class CatmaProject:
                 {metric_name}: {metric_result}
                 
                 
-                Confusion Matrix
-                ----------------
+                {matrix_type}
+                {len(matrix_type) * '-'}
                 """
             ))
             print(confusion_matrix)

--- a/gitma/project.py
+++ b/gitma/project.py
@@ -105,7 +105,6 @@ def get_ac_name(project_uuid: str, directory: str) -> str:
     Args:
         project_uuid (str): CATMA project UUID
         directory (str): annotation collection directory
-        test_positive (bool, optional): what should be returned if it is intrinsic markup. Defaults to True.
 
     Returns:
         str: annotation collection name
@@ -124,10 +123,11 @@ def load_annotation_collections(
     """Generates list and dict of CATMA annotation collections.
 
     Args:
-        project_uuid (str): CATMA project UUID.
-        included_acs (list): All listed annotation collections get loaded.
-        excluded_acs (list): All listed annotation collections don't get loaded.\
+        catma_project (CatmaProject): CATMA project.
+        included_acs (list, optional): All listed annotation collections get loaded.
+        excluded_acs (list, optional): All listed annotation collections don't get loaded.\
             If neither included nor excluded annotation collections are defined, all annotation collections get loaded.
+        ac_filter_keyword (str, optional): Only annotation collections with the given keyword get loaded.
 
     Returns:
         Tuple[List[AnnotationCollection], Dict[str, AnnotationCollection]]: List and dict of annotation collections.

--- a/gitma/project.py
+++ b/gitma/project.py
@@ -1077,13 +1077,15 @@ class CatmaProject:
 
         return pairwise_iaa_data
 
-    def calculate_krippendorff(
+    # TODO: use level parameter instead of tag_filter, implement filtering for properties?
+    def calculate_krippendorffs_alpha(
             self,
             ac_names: list = [],
             tag_filter: list = [],  # to be passed to gitma get_annotation_pairs function
             filter_both_ac: bool = True,  # to be passed to gitma get_annotation_pairs function
             include_empty_annotations: bool = True,  # passed to get_iaa_data function of gitma
             distance: str = 'binary',
+            verbose: bool = True
     ) -> Tuple[Union[float, Any], pd.DataFrame]:
         """
         Computes Krippendorff's Alpha inter-annotator-agreement (IAA) metric for multiple annotation collections based on NLTK implementation.
@@ -1097,6 +1099,7 @@ class CatmaProject:
                                                 included. Default is True. Passed to get_iaa_data function of gitma.
             distance (str, optional): The IAA distance function. Either 'binary' or 'interval'. See the\
                                           [NLTK API](https://www.nltk.org/api/nltk.metrics.html) for further information. Defaults to 'binary'.
+            verbose (bool, optional): Whether to print results to stdout. Defaults to `True`.
 
         Returns:
             Tuple[Union[Float, Any], pd.DataFrame]: The score for Krippendorff's alpha and a Pandas DataFrame with a co-ocurrence matrix.
@@ -1116,9 +1119,19 @@ class CatmaProject:
         )
 
         annotation_task = AnnotationTask(data=annotation_pairs, distance=distance_function)
-        print("Krippendorff's alpha [NLTK]: ", annotation_task.alpha())
-
         co_matrix = self.get_cooccurence_matrix(annotation_pairs)
+
+        if verbose:
+            print(textwrap.dedent(
+                f"""
+                Results for Krippendorff's alpha for project "{self.name}"
+                -------------{len(self.name) * '-'}-----------
+                Krippendorf's Alpha: {annotation_task.alpha()}
+                """
+            ))
+            # !TODO: should we print a warning that this is not a confusion matrix, but a co-occurence matrix?
+            print(co_matrix)
+
         # !TODO: look at the format of the return values, might want to follow the same format as other IAA calculations
         return annotation_task.alpha(), co_matrix
 

--- a/gitma/project.py
+++ b/gitma/project.py
@@ -1025,7 +1025,7 @@ class CatmaProject:
 
         if ac_names == []:
             print("No annotation collection names provided, using all ACs in the project.")
-            ac_names = list(project.ac_dict.keys())
+            ac_names = list(self.ac_dict.keys())
         else:
             print("Using provided annotation collection names: ", ac_names)
 


### PR DESCRIPTION
- Add function `calculate_krippendorffs_alpha` to projects
  - Krippendorffs Alpha can be calculated for two or more sets of annotations
  - The function `get_iaa_data_for_multiple_annotators` facilitates comparison of multiple sets of annotations
  - The function `get_cooccurrence_matrix` generates a co-occurrence matrix of all tags when comparing more than two annotation collections
- Update output for calculation results to fit the Krippendorffs alpha metric
- Update the Demo notebook `‎demo/notebooks/inter_annotator_agreement.ipynb‎` to include an example
- Small fixes for internal typing markup and documentation