### PR TITLE
update demo notebook for interannotator agreement scores

### DIFF
--- a/demo/notebooks/inter_annotator_agreement.ipynb
+++ b/demo/notebooks/inter_annotator_agreement.ipynb
@@ -28,7 +28,10 @@
     "  * [Basic example](#3.1)\n",
     "  * [Filter by tags](#3.2)\n",
     "  * [Compare annotation properties](#3.3)\n",
-    "* [`gamma_agreement()`](#4-bullet)"
+    "* [`calculate_krippendorffs_alpha()`](#4-bullet)\n",
+    "  * [Basic example](#4.1)\n",
+    "  * [Filter by tags](#4.2)\n",
+    "* [`gamma_agreement()`](#5-bullet)"
    ]
   },
   {
@@ -39,7 +42,7 @@
     "\n",
     "### nltk\n",
     "\n",
-    "If you are only interested in IAA metrics such as *Scott's pi*, *Cohen's kappa* and *Krippendorf's alpha*\n",
+    "If you are only interested in IAA metrics such as *Scott's pi*, *Cohen's kappa* and *Krippendorff's alpha*\n",
     "the [Natural Language Toolkit](https://www.nltk.org/) is sufficient (already installed).\n",
     "\n",
     "### pygamma-agreement\n",
@@ -192,28 +195,6 @@
    "metadata": {},
    "cell_type": "markdown",
    "source": [
-    "To compute the Krippendorff's alpha agreement for two or more annotatation collections, you can use the `calculate_krippendorffs_alpha()` method.\n",
-    "Krippendorff's alpha can be calculated for two or more annotation collections. If you do not supply a list of annotation collections,\n",
-    "the method will use all annotation collections in the project.\n",
-    "\n",
-    "The method returns the value for Krippendorff's alpha and a co-occurrence matrix of tag matches."
-   ]
-  },
-  {
-   "metadata": {},
-   "cell_type": "code",
-   "source": [
-    "krippendorffs_alpha, cooccurence_matrix = my_project.calculate_krippendorffs_alpha(\n",
-    "    ac_names=['ac_1', 'ac_2', 'gold_annotation']\n",
-    ")"
-   ],
-   "outputs": [],
-   "execution_count": null
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": [
     "### Filter by tags <a class=\"anchor\" id=\"3.2\"></a>\n",
     "\n",
     "There may occur cases in which you don't want to include all annotations in the computing of\n",
@@ -306,7 +287,88 @@
    "metadata": {},
    "cell_type": "markdown",
    "source": [
-    "## `gamma_agreement()` <a class=\"anchor\" id=\"4-bullet\"></a>\n",
+    "\n",
+    "## Calculate Krippendorff's Alpha for more than two annotators with `calculate_krippendorffs_alpha()` <a class=\"anchor\" id=\"4-bullet\"></a>\n"
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "To compute the Krippendorff's alpha agreement for two or more annotatation collections, you can use the `calculate_krippendorffs_alpha()` method.\n",
+    "Krippendorff's alpha can be calculated for two or more annotation collections. If you do not supply a list of annotation collections,\n",
+    "the method will use all annotation collections in the project.\n",
+    "\n",
+    "The method returns the value for Krippendorff's alpha and a co-occurrence matrix of tag matches.\n",
+    "\n",
+    "Analogue to the calculation of Scott's Pi and Cohen's Kappa, the best matching annotation spans are used for the calculation."
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "### Basic example <a class=\"anchor\" id=\"4.1\"></a>\n",
+    "\n",
+    "First, we will take a look at both annotation collections by comparing the annotation spans."
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "# compare the annotation collections by start point\n",
+    "my_project.compare_annotation_collections(\n",
+    "    annotation_collections=['ac_1', 'ac_2','gold_annotation']\n",
+    ")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Now, let's compute the Krippendorff's alpha score for all matching annotations:"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "krippendorffs_alpha, cooccurrence_matrix = my_project.calculate_krippendorffs_alpha(\n",
+    "    ac_names=['ac_1', 'ac_2', 'gold_annotation']\n",
+    ")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "### Filter by tags <a class=\"anchor\" id=\"4.2\"></a>\n",
+    "\n",
+    "There may occur cases in which you don't want to include all annotations in the computing of\n",
+    "the IAA scores.\n",
+    "In those cases just use the `tag_filter` parameter, which expects a list of tag names."
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "krippendorff, cooccurrence_matrix = my_project.calculate_krippendorffs_alpha(\n",
+    "    ac_names = ['ac_1', 'ac_2', 'gold_annotation'],\n",
+    "    tag_filter=['process_event']\n",
+    ")"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "## `gamma_agreement()` <a class=\"anchor\" id=\"5-bullet\"></a>\n",
     "\n",
     "To compute the gamma agreement, in addition to the annotation collections, 5 further parameters\n",
     "have to be defined.\n",


### PR DESCRIPTION
Update the demo jupyter notebook with a more detailed example on Krippendorff's alpha calculation.